### PR TITLE
Exit on SIGTERM

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,11 @@ import socket
 import random
 import os
 import argparse
+from signal import signal, SIGTERM
+
+
+def handler(signum, frame):
+  exit(0)
 
 app = Flask(__name__)
 
@@ -31,6 +36,7 @@ def main():
 
 
 if __name__ == "__main__":
+    signal(SIGTERM, handler)
 
     print(" This is a sample web application that displays a colored background. \n"
           " A color can be specified in two ways. \n"


### PR DESCRIPTION
PR Will make "docker stop" fast. It is annoying to need to wait on "kubectl delete pod" all the time.

Before:
```
docker run -it --rm --name kk kodekloud/webapp-color
docker stop kk  # wait 10 sec
```

After
```
docker build -t kodekloud/webapp-color:new .
docker run -it --rm --name kk kodekloud/webapp-color:new
docker stop kk  # no wait
```

Other than that, I like https://beta.kodekloud.com a lot. :)
